### PR TITLE
wd_get_default_gui_fontface: NONCLIENTMETRICS 

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -26,8 +26,6 @@
 #include "backend-dwrite.h"
 #include "backend-gdix.h"
 #include "lock.h"
-#include <stddef.h>
-
 
 static void
 wd_get_default_gui_fontface(WCHAR buffer[LF_FACESIZE])
@@ -37,7 +35,7 @@ wd_get_default_gui_fontface(WCHAR buffer[LF_FACESIZE])
 #if WINVER < 0x0600
     metrics.cbSize = sizeof(NONCLIENTMETRICSW);
 #else
-    metrics.cbSize = offsetof(NONCLIENTMETRICSW, iPaddedBorderWidth);
+    metrics.cbSize = WD_OFFSETOF(NONCLIENTMETRICSW, iPaddedBorderWidth);
 #endif
     SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, (void*) &metrics, 0);
     wcsncpy(buffer, metrics.lfMessageFont.lfFaceName, LF_FACESIZE);

--- a/src/font.c
+++ b/src/font.c
@@ -26,6 +26,7 @@
 #include "backend-dwrite.h"
 #include "backend-gdix.h"
 #include "lock.h"
+#include <stddef.h>
 
 
 static void
@@ -33,9 +34,10 @@ wd_get_default_gui_fontface(WCHAR buffer[LF_FACESIZE])
 {
     NONCLIENTMETRICSW metrics;
 
+#if WINVER < 0x0600
     metrics.cbSize = sizeof(NONCLIENTMETRICSW);
-#if WINVER >= 0x0600
-    metrics.cbSize -= sizeof(metrics.iPaddedBorderWidth);
+#else
+    metrics.cbSize = offsetof(NONCLIENTMETRICSW, iPaddedBorderWidth);
 #endif
     SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, (void*) &metrics, 0);
     wcsncpy(buffer, metrics.lfMessageFont.lfFaceName, LF_FACESIZE);


### PR DESCRIPTION
Consider MS extends NONCLIENTMETRICS in some future SDK.
In that case
`    metrics.cbSize -=...` 
will not work properly.
This small fix pins structure size to iPaddedBorderWidth field.
