### PR TITLE
Allow to apply abritrary affine transforms

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,6 +35,9 @@ target_link_libraries("draw-string" "windrawlib")
 add_executable("draw-styled" WIN32 "draw-styled.c")
 target_link_libraries("draw-styled" "windrawlib")
 
+add_executable("draw-transform" WIN32 "draw-transform.c")
+target_link_libraries("draw-transform" "windrawlib")
+
 add_executable("image-from-buffer" WIN32 "image-from-buffer.c" "image-from-buffer.h" "image-from-buffer.rc")
 target_link_libraries("image-from-buffer" "windrawlib")
 

--- a/examples/draw-simple.c
+++ b/examples/draw-simple.c
@@ -27,11 +27,22 @@ MainWinPaintToCanvas(WD_HCANVAS hCanvas)
         float x = 10.0f + i * 20.0f;
         float y = 10.0f + i * 20.0f;
 
+
+        WD_MATRIX m;
+        m.m11 = 1.2f;
+        m.m12 = 0;
+        m.m21 = 0;
+        m.m22 = 1.2f;
+        m.dx = 0;
+        m.dy = 0;
+        wdSetWorldTransform(hCanvas, &m);
+
         wdSetSolidBrushColor(hBrush, fillColors[i]);
         wdFillRect(hCanvas, hBrush, x, y, x + 100.0f, y + 100.0f);
 
         wdSetSolidBrushColor(hBrush, drawColors[i]);
         wdDrawRect(hCanvas, hBrush, x, y, x + 100.0f, y + 100.0f, 3.0f);
+        //wdResetWorld(hCanvas);
     }
 
     for(i = 0; i < 3; i++) {
@@ -115,7 +126,7 @@ _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, int nC
     WNDCLASS wc = { 0 };
     MSG msg;
 
-    wdPreInitialize(NULL, NULL, 0);
+    wdPreInitialize(NULL, NULL, WD_DISABLE_D2D);
     wdInitialize(0);
 
     /* Register main window class */

--- a/examples/draw-transform.c
+++ b/examples/draw-transform.c
@@ -56,7 +56,7 @@ MainWinPaintToCanvas(WD_HCANVAS hCanvas)
         m.m22 = 1.0f - i * 0.2f;
         m.dx = 0;
         m.dy = 0;
-        wdMultiplyWorldTransform(hCanvas, &m);
+        wdTransformWorld(hCanvas, &m);
 
         wdSetSolidBrushColor(hBrush, drawColors[i]);
         wdDrawRect(hCanvas, hBrush, 0, 0, 100.0f, 100.0f, 3.0f);

--- a/examples/draw-transform.c
+++ b/examples/draw-transform.c
@@ -26,44 +26,40 @@ MainWinPaintToCanvas(WD_HCANVAS hCanvas)
     for(i = 0; i < 3; i++) {
         float x = 10.0f + i * 20.0f;
         float y = 10.0f + i * 20.0f;
+        
+        wdTranslateWorld(hCanvas, x, y);
 
-        wdSetSolidBrushColor(hBrush, fillColors[i]);
-        wdFillRect(hCanvas, hBrush, x, y, x + 100.0f, y + 100.0f);
+        wdSetSolidBrushColor(hBrush, drawColors[i]);
+        wdDrawRect(hCanvas, hBrush, 0, 0, 50.0f, 50.0f, 3.0f);
+    }
+
+    wdResetWorld(hCanvas);
+
+    for(i = 0; i < 3; i++) {
+        float x = 200.0f;
+        float y = 30.0f;
+
+        wdRotateWorld(hCanvas, x + 50.0f, y + 50.0f, 15.0f * i);
 
         wdSetSolidBrushColor(hBrush, drawColors[i]);
         wdDrawRect(hCanvas, hBrush, x, y, x + 100.0f, y + 100.0f, 3.0f);
     }
 
-    for(i = 0; i < 3; i++) {
-        float x = 250.0f + i * 20.0f;
-        float y = 60.0f + i * 20.0f;
+    wdResetWorld(hCanvas);
 
-        wdSetSolidBrushColor(hBrush, fillColors[i]);
-        wdFillCircle(hCanvas, hBrush, x, y, 55.0f);
+    wdTranslateWorld(hCanvas, 350, 30);
+    for(i = 0; i < 3; i++) {
+        WD_MATRIX m;
+        m.m11 = 1.0f + i * 0.2f;
+        m.m12 = 0;
+        m.m21 = 0;
+        m.m22 = 1.0f - i * 0.2f;
+        m.dx = 0;
+        m.dy = 0;
+        wdMultiplyWorldTransform(hCanvas, &m);
 
         wdSetSolidBrushColor(hBrush, drawColors[i]);
-        wdDrawCircle(hCanvas, hBrush, x, y, 55.0f, 3.0f);
-    }
-
-    for(i = 0; i < 3; i++) {
-        float x = 360.0f + i * 20.0f;
-        float y = 60.0f + i * 20.0f;
-
-        WD_HPATH hPath = wdCreatePath(hCanvas);
-        WD_PATHSINK sink;
-        wdOpenPathSink(&sink, hPath);
-        wdBeginFigure(&sink, x, y);
-        wdAddBezier(&sink, x + 50, y - 80, x + 80, y + 80, x + 120, y);
-        wdEndFigure(&sink, FALSE);
-        wdClosePathSink(&sink);
-
-        wdSetSolidBrushColor(hBrush, fillColors[i]);
-        wdFillPath(hCanvas, hBrush, hPath);
-
-        wdSetSolidBrushColor(hBrush, drawColors[i]);
-        wdDrawPath(hCanvas, hBrush, hPath, 3.0f);
-
-        wdDestroyPath(hPath);
+        wdDrawRect(hCanvas, hBrush, 0, 0, 100.0f, 100.0f, 3.0f);
     }
 
     wdDestroyBrush(hBrush);

--- a/include/wdl.h
+++ b/include/wdl.h
@@ -261,7 +261,7 @@ void wdSetClip(WD_HCANVAS hCanvas, const WD_RECT* pRect, const WD_HPATH hPath);
  */
 void wdRotateWorld(WD_HCANVAS hCanvas, float cx, float cy, float fAngle);
 void wdTranslateWorld(WD_HCANVAS hCanvas, float dx, float dy);
-void wdMultiplyWorldTransform(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix);
+void wdTransformWorld(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix);
 void wdResetWorld(WD_HCANVAS hCanvas);
 
 

--- a/include/wdl.h
+++ b/include/wdl.h
@@ -98,6 +98,15 @@ struct WD_RECT_tag {
     float y1;
 };
 
+typedef struct WD_MATRIX_tag WD_MATRIX;
+struct WD_MATRIX_tag {
+    float m11;
+    float m12;
+    float m21;
+    float m22;
+    float dx;
+    float dy;
+};
 
 /************************
  ***  Initialization  ***
@@ -252,6 +261,7 @@ void wdSetClip(WD_HCANVAS hCanvas, const WD_RECT* pRect, const WD_HPATH hPath);
  */
 void wdRotateWorld(WD_HCANVAS hCanvas, float cx, float cy, float fAngle);
 void wdTranslateWorld(WD_HCANVAS hCanvas, float dx, float dy);
+void wdSetWorldTransform(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix);
 void wdResetWorld(WD_HCANVAS hCanvas);
 
 

--- a/include/wdl.h
+++ b/include/wdl.h
@@ -261,7 +261,7 @@ void wdSetClip(WD_HCANVAS hCanvas, const WD_RECT* pRect, const WD_HPATH hPath);
  */
 void wdRotateWorld(WD_HCANVAS hCanvas, float cx, float cy, float fAngle);
 void wdTranslateWorld(WD_HCANVAS hCanvas, float dx, float dy);
-void wdSetWorldTransform(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix);
+void wdMultiplyWorldTransform(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix);
 void wdResetWorld(WD_HCANVAS hCanvas);
 
 

--- a/src/backend-gdix.c
+++ b/src/backend-gdix.c
@@ -113,8 +113,9 @@ gdix_init(void)
     GPA(SetPixelOffsetMode, (dummy_GpGraphics*, dummy_GpPixelOffsetMode));
     GPA(SetSmoothingMode, (dummy_GpGraphics*, dummy_GpSmoothingMode));
     GPA(TranslateWorldTransform, (dummy_GpGraphics*, float, float, dummy_GpMatrixOrder));
-    GPA(SetWorldTransform, (dummy_GpGraphics*, dummy_GpMatrix*, dummy_GpMatrixOrder));
+    GPA(MultiplyWorldTransform, (dummy_GpGraphics*, dummy_GpMatrix*, dummy_GpMatrixOrder));
     GPA(CreateMatrix2, (float, float, float, float, float, float, dummy_GpMatrix**));
+    GPA(DeleteMatrix, (dummy_GpMatrix*));
 
     /* Brush functions */
     GPA(CreateSolidFill, (dummy_ARGB, dummy_GpSolidFill**));
@@ -388,6 +389,16 @@ gdix_reset_transform(gdix_canvas_t* c)
     gdix_vtable->fn_ResetWorldTransform(c->graphics);
     if(c->rtl)
         gdix_rtl_transform(c);
+}
+
+void
+gdix_delete_matrix(dummy_GpMatrix* m)
+{
+    int status = gdix_vtable->fn_DeleteMatrix(m);
+    if(status != 0) {
+        WD_TRACE_ERR_("wdSetWorldTransform: Could not delete matrix", status);
+        return;
+    }
 }
 
 void

--- a/src/backend-gdix.c
+++ b/src/backend-gdix.c
@@ -113,6 +113,8 @@ gdix_init(void)
     GPA(SetPixelOffsetMode, (dummy_GpGraphics*, dummy_GpPixelOffsetMode));
     GPA(SetSmoothingMode, (dummy_GpGraphics*, dummy_GpSmoothingMode));
     GPA(TranslateWorldTransform, (dummy_GpGraphics*, float, float, dummy_GpMatrixOrder));
+    GPA(SetWorldTransform, (dummy_GpGraphics*, dummy_GpMatrix*, dummy_GpMatrixOrder));
+    GPA(CreateMatrix2, (float, float, float, float, float, float, dummy_GpMatrix**));
 
     /* Brush functions */
     GPA(CreateSolidFill, (dummy_ARGB, dummy_GpSolidFill**));

--- a/src/backend-gdix.h
+++ b/src/backend-gdix.h
@@ -74,8 +74,9 @@ struct gdix_vtable_tag {
     int (WINAPI* fn_SetPixelOffsetMode)(dummy_GpGraphics*, dummy_GpPixelOffsetMode);
     int (WINAPI* fn_SetSmoothingMode)(dummy_GpGraphics*, dummy_GpSmoothingMode);
     int (WINAPI* fn_TranslateWorldTransform)(dummy_GpGraphics*, float, float, dummy_GpMatrixOrder);
-    int (WINAPI* fn_SetWorldTransform)(dummy_GpGraphics*, dummy_GpMatrix*, dummy_GpMatrixOrder);
+    int (WINAPI* fn_MultiplyWorldTransform)(dummy_GpGraphics*, dummy_GpMatrix*, dummy_GpMatrixOrder);
     int (WINAPI* fn_CreateMatrix2)(float, float, float, float, float, float, dummy_GpMatrix**);
+    int (WINAPI* fn_DeleteMatrix)(dummy_GpMatrix*);
 
     /* Brush functions */
     int (WINAPI* fn_CreateSolidFill)(dummy_ARGB, dummy_GpSolidFill**);
@@ -178,6 +179,7 @@ gdix_canvas_t* gdix_canvas_alloc(HDC dc, const RECT* doublebuffer_rect, UINT wid
 void gdix_canvas_free(gdix_canvas_t* c);
 void gdix_rtl_transform(gdix_canvas_t* c);
 void gdix_reset_transform(gdix_canvas_t* c);
+void gdix_delete_matrix(dummy_GpMatrix* m);
 void gdix_canvas_apply_string_flags(gdix_canvas_t* c, DWORD flags);
 void gdix_setpen(dummy_GpPen* pen, dummy_GpBrush* brush, float width, gdix_strokestyle_t* style);
 dummy_GpBitmap* gdix_bitmap_from_HBITMAP_with_alpha(HBITMAP hBmp, BOOL has_premultiplied_alpha);

--- a/src/backend-gdix.h
+++ b/src/backend-gdix.h
@@ -74,6 +74,8 @@ struct gdix_vtable_tag {
     int (WINAPI* fn_SetPixelOffsetMode)(dummy_GpGraphics*, dummy_GpPixelOffsetMode);
     int (WINAPI* fn_SetSmoothingMode)(dummy_GpGraphics*, dummy_GpSmoothingMode);
     int (WINAPI* fn_TranslateWorldTransform)(dummy_GpGraphics*, float, float, dummy_GpMatrixOrder);
+    int (WINAPI* fn_SetWorldTransform)(dummy_GpGraphics*, dummy_GpMatrix*, dummy_GpMatrixOrder);
+    int (WINAPI* fn_CreateMatrix2)(float, float, float, float, float, float, dummy_GpMatrix**);
 
     /* Brush functions */
     int (WINAPI* fn_CreateSolidFill)(dummy_ARGB, dummy_GpSolidFill**);

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -467,7 +467,7 @@ wdTranslateWorld(WD_HCANVAS hCanvas, float dx, float dy)
 }
 
 void
-wdMultiplyWorldTransform(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix)
+wdTransformWorld(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix)
 {
     if(pMatrix == NULL) {
         WD_TRACE("wdSetWorldTransform: Invalid pMatrix");

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -467,6 +467,31 @@ wdTranslateWorld(WD_HCANVAS hCanvas, float dx, float dy)
 }
 
 void
+wdSetWorldTransform(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix)
+{
+    if(d2d_enabled()) {
+        d2d_canvas_t* c = (d2d_canvas_t*) hCanvas;
+        dummy_D2D1_MATRIX_3X2_F m;
+
+        m._11 = pMatrix->m11;
+        m._12 = pMatrix->m12;
+        m._21 = pMatrix->m21;
+        m._22 = pMatrix->m22;
+        m._31 = pMatrix->dx;
+        m._32 = pMatrix->dy;
+        d2d_apply_transform(c, &m);
+    } else {
+        gdix_canvas_t* c = (gdix_canvas_t*) hCanvas;
+
+        dummy_GpMatrix* matrix;
+        gdix_vtable->fn_CreateMatrix2(pMatrix->m11, pMatrix->m12,
+                                      pMatrix->m21, pMatrix->m22,
+                                      pMatrix->dx, pMatrix->dy, &matrix);
+        gdix_vtable->fn_SetWorldTransform(c->graphics, matrix, dummy_MatrixOrderAppend);
+    }
+}
+
+void
 wdResetWorld(WD_HCANVAS hCanvas)
 {
     if(d2d_enabled()) {

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -467,13 +467,12 @@ wdTranslateWorld(WD_HCANVAS hCanvas, float dx, float dy)
 }
 
 void
-wdSetWorldTransform(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix)
+wdMultiplyWorldTransform(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix)
 {
     if(pMatrix == NULL) {
         WD_TRACE("wdSetWorldTransform: Invalid pMatrix");
         return;
     }
-    wdResetWorld(hCanvas);
     if(d2d_enabled()) {
         d2d_canvas_t* c = (d2d_canvas_t*) hCanvas;
 
@@ -498,7 +497,7 @@ wdSetWorldTransform(WD_HCANVAS hCanvas, const WD_MATRIX* pMatrix)
             WD_TRACE_ERR_("wdSetWorldTransform: GdpiCreateMatrix2() failed", status);
             return;
         }
-        status = gdix_vtable->fn_MultiplyWorldTransform(c->graphics, matrix, dummy_MatrixOrderAppend);
+        status = gdix_vtable->fn_MultiplyWorldTransform(c->graphics, matrix, dummy_MatrixOrderPrepend);
         if(status != 0) {
             WD_TRACE_ERR_("wdSetWorldTransform: MultiplyWorldTransform() failed", status);
             gdix_delete_matrix(matrix);

--- a/src/dummy/gdiplus.h
+++ b/src/dummy/gdiplus.h
@@ -221,6 +221,7 @@ typedef struct dummy_GpImage_tag        dummy_GpImage;
 typedef struct dummy_GpPath_tag         dummy_GpPath;
 typedef struct dummy_GpPen_tag          dummy_GpPen;
 typedef struct dummy_GpStringFormat_tag dummy_GpStringFormat;
+typedef struct dummy_GpMatrix_tag       dummy_GpMatrix;
 
 /* These are "derived" from the types aboves (more specialized). */
 typedef struct dummy_GpImage_tag        dummy_GpBitmap;


### PR DESCRIPTION
Aa alternative to (a otherwise useless) `WD_MATRIX`  it would be possible to pass the 6 floats as arguments to `wdSetWorldTransform`. However, the current implementation is more like the actual GDI+ API.